### PR TITLE
P2P release update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ coins
 mm2
 *.zip
 libmm2.a
-MM2.json
+MM2*.json
 mm2.log
 userpass
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Operators with the best metrics in terms of uptime and responsiveness to updates
 
 **For each hour of uptime with the correct version, Notary Nodes will receive 0.2 points to their season score.**
 
-You'll need to open port 38890 - `sudo ufw allow 38890`
-
-
-
 The simple scripts in this repository will assist operators in setting up their seed node and keeping it up to date whenever update announcements are broadcast.
 
 ## gen_conf.py
@@ -100,10 +96,11 @@ Once the certs are generated, add entries to your MM2.json as below, substitutin
 ### Step 3: Open the mm2 Seednode WSS Port, and Close Port 80
 
 ```bash
-sudo ufw allow 38900
+sudo ufw allow 42845 comment 'MM2 Seednode TCP'
+sudo ufw allow 42855 comment 'MM2 Seednode WSS'
 sudo ufw status numbered    # To find the ID numbers for port 80
-sudo ufw delete 20          # Remove port 80 on ipv6
-sudo ufw delete 10          # Remove port 80 on ipv4
+sudo ufw delete 20          # Remove port 80 on ipv6 by ID number
+sudo ufw delete 10          # Remove port 80 on ipv4 by ID number
 ```
 
 ### Step 4: Restart MM2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Basic scripts for running a MM2 Seed Node on your Notary Node
 
-Komodo Platform's [AtomicDEX-API](https://github.com/KomodoPlatform/atomicDEX-API) is an open-source atomic-swap protocol for trading seamlessly between essentially any blockchain asset in existence. Seed nodes play an essential part in orderbook propagation and relaying information about peers within the network and the status of swaps in progress. 
+Komodo Platform's [komodo-defi-framework](https://github.com/KomodoPlatform/komodo-defi-framework) is an open-source atomic-swap protocol for trading seamlessly between essentially any blockchain asset in existence. Seed nodes play an essential part in orderbook propagation and relaying information about peers within the network and the status of swaps in progress. 
 
 With the start of the 5th Komodo Notary Node Season, operators will be running a seed node on their third party (3P) server to further decentralize the network. This expands the current number of seed nodes from half a dozen to over 60 nodes, distributed geographically across the planet, and maintained by a diverse group of respected people within the Komodo community with great expertise in KMD related technologies and the ability to rapidly deploy updates and assist each other with troubleshooting as required.
 
@@ -17,7 +17,7 @@ Creates an **MM2.json** config file to define node as seed.
 Downloads latest **coins** file from https://github.com/KomodoPlatform/coins/
 
 ## update_mm2.sh
-Downloads latest **mm2** binary from https://github.com/KomodoPlatform/atomicDEX-API/releases
+Downloads latest **mm2** binary from https://github.com/KomodoPlatform/komodo-defi-framework/releases
 
 ## run_mm2.sh
 Launches mm2, and logs output.
@@ -123,7 +123,7 @@ Once it looks like it is working, you can confirm external connections are being
 
 
 # Additional Resources
-- Developer docs: https://developers.komodoplatform.com/basic-docs/atomicdex-api-legacy/rational_number_note.html
+- Developer docs: https://developers.komodoplatform.com/
 - Cipi's MM2 scripts: https://github.com/cipig/mmtools
 - PytomicDEX: https://github.com/smk762/pytomicDEX_makerbot
 
@@ -139,9 +139,9 @@ rustup component add rustfmt-preview
 ```
 - Build mm2:
 ```
-git clone https://github.com/KomodoPlatform/atomicDEX-API
-cd atomicDEX-API
+git clone https://github.com/KomodoPlatform/komodo-defi-framework
+cd komodo-defi-framework
 git checkout b8598439a # check for latest valid version hash at https://github.com/smk762/DragonhoundTools/blob/master/atomicdex/seednode_version.json
 cargo build -vv
 ```
-Additional build notes at https://github.com/KomodoPlatform/atomicDEX-API/#building-from-source
+Additional build notes at https://github.com/KomodoPlatform/komodo-defi-framework/#building-from-source

--- a/gen_conf.py
+++ b/gen_conf.py
@@ -7,7 +7,7 @@ import mnemonic
 
 conf = {
     "gui": "NN_SEED",
-    "netid": 7777,
+    "netid": 8762,
     "i_am_seed":True,
     "rpc_password": "RPC_CONTROL_USERPASSWORD",
     "passphrase": "YOUR SEED PHRASE",

--- a/gen_conf.py
+++ b/gen_conf.py
@@ -11,7 +11,13 @@ conf = {
     "i_am_seed":True,
     "rpc_password": "RPC_CONTROL_USERPASSWORD",
     "passphrase": "YOUR SEED PHRASE",
-    "userhome": "/${HOME#\"/\"}"
+    "userhome": "/${HOME#\"/\"}",
+        "seednodes": [
+            "streamseed1.komodo.earth",
+            "streamseed2.komodo.earth",
+            "streamseed3.komodo.earth",
+            "streamwatchtower1.komodo.earth"
+        ]
 }
 
 special_chars = ["@", "~", "-", "_", "|", ":", "+"]
@@ -60,3 +66,7 @@ if resp in ["Y", "y"]:
 	with open("userpass", "w+") as f:
 		f.write(f'userpass="{rpc_password}"')
 	print("userpass file created.")
+	print("Please make sure you have opened the p2p ports.")
+	print("sudo ufw allow 42845 comment 'MM2 Seednode TCP'")
+	print("sudo ufw allow 42855 comment 'MM2 Seednode WSS'")
+ 

--- a/test_wss.py
+++ b/test_wss.py
@@ -18,4 +18,4 @@ def get_from_electrum_ssl(url, port, method, params=[]):
 
 data = {"userpass": "userpass"}
 domain = input("Enter domain: ")
-print(get_from_electrum_ssl(domain, 38900, "version", data))
+print(get_from_electrum_ssl(domain, 42855, "version", data))

--- a/update_conf.py
+++ b/update_conf.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import time
+import json
+import os.path
+
+if os.path.exists("MM2.json"):
+    conf = json.load(open("MM2.json"))
+    fn = f"MM2_backup_{int(time.time())}.json"
+    json.dump(conf, open(fn, "w+"), indent=4)
+    print(f"Old MM2,json file backed up as {fn}")
+    conf.update({
+        "netid": 8762,
+        "seednodes": [
+            "streamseed1.komodo.earth",
+            "streamseed2.komodo.earth",
+            "streamseed3.komodo.earth",
+            "streamwatchtower1.komodo.earth"
+        ]
+    })
+
+    with open("MM2.json", "w+") as f:
+        json.dump(conf, f, indent=4)
+
+    print("MM2.json file updated for netID 8762!")
+else:
+    print("MM2.json file not found! Please run ./gen_conf.py first.")

--- a/update_mm2.sh
+++ b/update_mm2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 rm mm2
-wget $(curl -vvv https://api.github.com/repos/KomodoPlatform/atomicDEX-API/releases | jq -r '.[0].assets | map(select(.name | contains("Linux-Release."))) | .[0].browser_download_url') -O mm2.zip
+wget $(curl -vvv https://api.github.com/repos/KomodoPlatform/komodo-defi-framework/releases | jq -r '.[0].assets | map(select(.name | contains("Linux-Release."))) | .[0].browser_download_url') -O mm2.zip
 unzip mm2.zip
 rm mm2.zip

--- a/update_mm2.sh
+++ b/update_mm2.sh
@@ -3,3 +3,6 @@ rm mm2
 wget $(curl -vvv https://api.github.com/repos/KomodoPlatform/komodo-defi-framework/releases | jq -r '.[0].assets | map(select(.name | contains("Linux-Release."))) | .[0].browser_download_url') -O mm2.zip
 unzip mm2.zip
 rm mm2.zip
+sudo ufw allow 42845 comment 'MM2 Seednode TCP'
+sudo ufw allow 42855 comment 'MM2 Seednode WSS'
+echo "Please run ./update_conf.py before restarting './mm2' to update your NetID."


### PR DESCRIPTION
- changes ports for next release
- updates api repo name

NN ops will need to change the netid in their MM2.json files to `8762`.

Open the ports:
```
sudo ufw allow 42845 comment 'MM2 Seednode TCP'
sudo ufw allow 42855 comment 'MM2 Seednode WSS'
```
and update default seednodes (these should be hardcoded in mm2 either way)

        "seednodes": [
            "streamseed1.komodo.earth",
            "streamseed2.komodo.earth",
            "streamseed3.komodo.earth",
            "streamwatchtower1.komodo.earth"
        ]