### PR TITLE
add cloudflare dns plugin support, bind kdf rpc to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The included `docker-compose.yml` provides a turnkey setup. It provisions/renews
 ```bash
 DOMAIN=your.subdomain.tld
 LETSENCRYPT_EMAIL=you@example.com
+# Optional: CloudFlare API token for DNS-01 challenge (no port 80 needed)
+# Get your token from: https://dash.cloudflare.com/profile/api-tokens
+# Create a token with "Edit zone DNS" permissions for your domain
+# CLOUDFLARE_API_TOKEN=your_cloudflare_api_token_here
 # Optional: predefine RPC password (else generated/loaded)
 USERPASS=RPC_UserP@SSW0RD
 # Optional: predefine your mm2 passphrase (else generated)
@@ -21,16 +25,20 @@ docker compose up -d --build && docker compose logs -f --tail 5
 ```
 
 
-### Step 4: Open the KDF Seednode Ports, and Close Port 80
+### Step 4: Open the KDF Seednode Ports
 
 ```bash
 sudo ufw allow 42855
 sudo ufw allow 42845
 ```
 
+**Note about port 80:** If you're using CloudFlare DNS plugin (by setting `CLOUDFLARE_API_TOKEN`), port 80 is not needed and can remain closed. Otherwise, port 80 must be open for Let's Encrypt HTTP validation.
+
 Notes:
-- Certificates are created by the `certbot` service and mounted read-only to the `kdf` service. Certbot needs port 80 open to request and update certs. - 
+- Certificates are created by the `certbot` service and mounted read-only to the `kdf` service.
+- **CloudFlare DNS Plugin:** If `CLOUDFLARE_API_TOKEN` is set in `.env`, certbot will use CloudFlare DNS-01 challenge instead of HTTP validation. This means port 80 doesn't need to be open. The token should have "Edit zone DNS" permissions for your domain. Get your token from [CloudFlare API Tokens](https://dash.cloudflare.com/profile/api-tokens).
+- **Standalone Mode (default):** If `CLOUDFLARE_API_TOKEN` is not set, certbot uses standalone HTTP challenge on port 80. Ensure TCP/80 is reachable from the internet for issuance and renewals.
 - `run_mm2.sh` auto-updates `MM2.json` `seednodes` from the remote list on each start.
 - First boot is non-interactive: if `MM2.json` does not exist, it is generated automatically using `USERPASS` and `PASSPHRASE` envs (or securely generated defaults). If `DOMAIN` is set and certificates exist, `wss_certs` is added automatically.
-- Certbot runs continuously inside its container and will attempt automatic renewals every ~12 hours using the standalone HTTP challenge on port 80. Ensure TCP/80 is reachable from the internet for issuance and renewals.
+- Certbot runs continuously inside its container and will attempt automatic renewals every ~12 hours.
 - The `coins` file is refreshed automatically on each start from `https://raw.githubusercontent.com/GLEECBTC/coins/refs/heads/master/coins` and saved to `~/.kdf/coins` inside the container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   certbot:
-    image: certbot/certbot:latest
+    image: certbot/dns-cloudflare:latest
     entrypoint: []
     command:
       - /bin/sh
@@ -9,30 +9,71 @@ services:
         echo "Certbot: starting for DOMAIN=${DOMAIN}"
         if [ -z "${DOMAIN:-}" ] || [ -z "${LETSENCRYPT_EMAIL:-}" ]; then
           echo "Certbot: DOMAIN and LETSENCRYPT_EMAIL must be set"; sleep 3600; exit 1; fi
-        certbot certonly --standalone --non-interactive --agree-tos \
-          -m "${LETSENCRYPT_EMAIL}" -d "${DOMAIN}" --keep-until-expiring \
-          --preferred-challenges http || true
-        # Export readable copies for mm2 (avoid archive symlink/permissions)
-        mkdir -p /etc/letsencrypt/export/"${DOMAIN}"
-        cp -L /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
-        cp -L /etc/letsencrypt/live/"${DOMAIN}"/privkey.pem /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
-        chmod 644 /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
-        chmod 600 /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
-        while :; do
-          echo "Certbot: running renewal check..."
-          certbot renew --standalone --no-random-sleep-on-renew || true
+        
+        # Check if CloudFlare API token is provided
+        if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
+          echo "Certbot: Using CloudFlare DNS plugin"
+          # Create CloudFlare credentials file
+          mkdir -p /etc/letsencrypt
+          echo "dns_cloudflare_api_token = ${CLOUDFLARE_API_TOKEN}" > /etc/letsencrypt/cloudflare.ini
+          chmod 600 /etc/letsencrypt/cloudflare.ini
+          
+          # Initial certificate request with DNS challenge
+          certbot certonly --dns-cloudflare --dns-cloudflare-credentials /etc/letsencrypt/cloudflare.ini \
+            --non-interactive --agree-tos -m "${LETSENCRYPT_EMAIL}" -d "${DOMAIN}" \
+            --keep-until-expiring || true
+          
+          # Export readable copies for mm2 (avoid archive symlink/permissions)
           mkdir -p /etc/letsencrypt/export/"${DOMAIN}"
           cp -L /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
           cp -L /etc/letsencrypt/live/"${DOMAIN}"/privkey.pem /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
           chmod 644 /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
           chmod 600 /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
-          sleep 12h
-        done
+          
+          while :; do
+            echo "Certbot: running renewal check..."
+            certbot renew --dns-cloudflare --dns-cloudflare-credentials /etc/letsencrypt/cloudflare.ini \
+              --no-random-sleep-on-renew || true
+            mkdir -p /etc/letsencrypt/export/"${DOMAIN}"
+            cp -L /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
+            cp -L /etc/letsencrypt/live/"${DOMAIN}"/privkey.pem /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
+            chmod 644 /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
+            chmod 600 /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
+            sleep 12h
+          done
+        else
+          echo "Certbot: Using standalone mode (port 80 required)"
+          certbot certonly --standalone --non-interactive --agree-tos \
+            -m "${LETSENCRYPT_EMAIL}" -d "${DOMAIN}" --keep-until-expiring \
+            --preferred-challenges http || true
+          # Export readable copies for mm2 (avoid archive symlink/permissions)
+          mkdir -p /etc/letsencrypt/export/"${DOMAIN}"
+          cp -L /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
+          cp -L /etc/letsencrypt/live/"${DOMAIN}"/privkey.pem /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
+          chmod 644 /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
+          chmod 600 /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
+          while :; do
+            echo "Certbot: running renewal check..."
+            certbot renew --standalone --no-random-sleep-on-renew || true
+            mkdir -p /etc/letsencrypt/export/"${DOMAIN}"
+            cp -L /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
+            cp -L /etc/letsencrypt/live/"${DOMAIN}"/privkey.pem /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
+            chmod 644 /etc/letsencrypt/export/"${DOMAIN}"/fullchain.pem || true
+            chmod 600 /etc/letsencrypt/export/"${DOMAIN}"/privkey.pem || true
+            sleep 12h
+          done
+        fi
     environment:
       - DOMAIN=${DOMAIN}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:-}
       - USER_ID=${USER_ID:-1000}
       - GROUP_ID=${GROUP_ID:-1000}
+    # Port 80 is only needed for standalone mode (when CLOUDFLARE_API_TOKEN is not set)
+    # When using CloudFlare DNS plugin, port 80 is not needed and won't be used.
+    # Note: docker-compose doesn't support conditional port mapping, so port 80 will be mapped
+    # but remain unused when DNS plugin is active. To completely disable port mapping,
+    # you can manually remove this ports section when using DNS plugin.
     ports:
       - "80:80"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - .:/home/komodian/kdf
       - letsencrypt:/etc/letsencrypt:ro
     ports:
-      - "7783:7783"
+      - "127.0.0.1:7783:7783"
       - "42855:42855"
       - "42845:42845"
     depends_on:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Cloudflare DNS-based SSL issuance and automated renewal when an API token is provided; standalone HTTP-based certificate workflow remains when token is not configured.

* **Chores**
  * KDF service port binding restricted to localhost.

* **Documentation**
  * README updated to clarify port 80 requirements and certificate behaviors for DNS-based vs standalone issuance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->